### PR TITLE
Fix empty state blocking UI interactions

### DIFF
--- a/src/ui/flashcard-browser-view.ts
+++ b/src/ui/flashcard-browser-view.ts
@@ -412,7 +412,7 @@ export class FlashcardBrowserView extends ItemView {
    * Render empty state for deck list
    */
   private renderDeckListEmptyState(container: HTMLElement, isActuallyEmpty: boolean) {
-    const emptyState = container.createDiv({ cls: 'empty-state' });
+    const emptyState = container.createDiv({ cls: 'empty-state deck-list-empty-state' });
     const emptyIcon = emptyState.createEl('div', { cls: 'empty-icon' });
     setIcon(emptyIcon, this.deckSearchQuery ? 'search' : 'inbox');
     emptyState.createEl('div', {

--- a/styles.css
+++ b/styles.css
@@ -805,6 +805,11 @@
   color: var(--text-muted);
 }
 
+/* Override height for deck list empty state to prevent blocking interactions */
+.deck-list-empty-state {
+  height: auto;
+}
+
 .empty-icon {
   font-size: 4em;
   margin-bottom: 16px;


### PR DESCRIPTION
Added .deck-list-empty-state class to override height: 100% with height: auto. The original height: 100% was causing the empty state to expand within the CSS Grid container and block interactions with the search bar and header buttons.