### PR TITLE
Fix TypeScript linting and code quality issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
       "@typescript-eslint/no-unnecessary-type-constraint": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
       "@typescript-eslint/no-base-to-string": "error",
+      "no-console": ["error", { "allow": ["warn", "error", "debug"] }],
       "no-restricted-properties": ["error", {
         "property": "innerHTML",
         "message": "Do not write to DOM directly using innerHTML property"
@@ -35,5 +36,15 @@
         "property": "outerHTML",
         "message": "Do not write to DOM directly using outerHTML property"
       }]
-    }
+    },
+    "overrides": [
+      {
+        "files": ["__tests__/**/*.ts", "__mocks__/**/*.ts"],
+        "rules": {
+          "@typescript-eslint/no-explicit-any": "off",
+          "@typescript-eslint/no-unsafe-argument": "off",
+          "@typescript-eslint/await-thenable": "off"
+        }
+      }
+    ]
   }

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -29,7 +29,7 @@ global.window = {
 } as any;
 
 // Utility functions for tests
-export function createMockTFile(path: string, content: string = ''): any {
+export function createMockTFile(path: string, content = ''): any {
   return {
     path,
     basename: path.split('/').pop()?.replace(/\.[^/.]+$/, '') || '',

--- a/main.ts
+++ b/main.ts
@@ -188,7 +188,7 @@ export default class FlashlyPlugin extends Plugin {
 		}
 
 		if (leaf) {
-			workspace.revealLeaf(leaf);
+			await workspace.revealLeaf(leaf);
 		}
 	}
 
@@ -223,7 +223,7 @@ export default class FlashlyPlugin extends Plugin {
 		}
 
 		if (leaf) {
-			workspace.revealLeaf(leaf);
+			await workspace.revealLeaf(leaf);
 		}
 	}
 
@@ -245,7 +245,7 @@ export default class FlashlyPlugin extends Plugin {
 		}
 
 		if (leaf) {
-			workspace.revealLeaf(leaf);
+			await workspace.revealLeaf(leaf);
 		}
 	}
 

--- a/src/ui/quiz-view.ts
+++ b/src/ui/quiz-view.ts
@@ -24,9 +24,9 @@ export class QuizView extends ItemView {
 	private debounceTimer: number | null = null;
 
 	// Learn mode state
-	private learnModeEnabled: boolean = false;
+	private learnModeEnabled = false;
 	private questionQueue: number[] = [];
-	private currentQueuePosition: number = 0;
+	private currentQueuePosition = 0;
 	private answeredQuestions: Set<number> = new Set();
 
 	constructor(leaf: WorkspaceLeaf, plugin: FlashlyPlugin) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -28,7 +28,7 @@ export class Logger {
 	 */
 	log(...args: unknown[]): void {
 		if (this.isDebugEnabled) {
-			console.log('[Flashly]', ...args);
+			console.debug('[Flashly]', ...args);
 		}
 	}
 


### PR DESCRIPTION
- Add await to workspace.revealLeaf() calls to fix floating promises
- Replace console.log with console.debug in Logger utility
- Remove unnecessary type annotations for inferrable types
- Add ESLint overrides for test files to allow any types in mocks
- Add no-console rule to restrict to warn/error/debug methods only