### PR TITLE
Debug statistics and quiz history pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1595,7 +1595,9 @@
   height: 100%;
   padding: 20px;
   overflow-y: auto;
+  overflow-x: hidden;
   background: var(--background-primary);
+  box-sizing: border-box;
 }
 
 /* Stats Header */
@@ -3026,8 +3028,13 @@
 /* ========== QUIZ HISTORY VIEW ========== */
 
 .flashly-quiz-history-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   padding: 20px;
   overflow-y: auto;
+  overflow-x: hidden;
+  box-sizing: border-box;
 }
 
 .quiz-history-header {


### PR DESCRIPTION
The statistics and quiz history pages were not scrollable, making elements inaccessible when content exceeded the viewport height.

Root causes:
- Quiz history view was missing critical CSS properties (height: 100%, display: flex, flex-direction: column)
- Both views were missing overflow-x: hidden and box-sizing: border-box for proper layout handling

Changes:
- Added height: 100% to quiz history view to fill vertical space
- Added display: flex and flex-direction: column for proper layout
- Added overflow-x: hidden to prevent horizontal scrolling
- Added box-sizing: border-box to both views for correct sizing with padding

This ensures content scrolls properly when it exceeds the available vertical space in both views.