### PR TITLE
Fix plugin code style and async issues

### DIFF
--- a/src/commands/generate-quiz-command.ts
+++ b/src/commands/generate-quiz-command.ts
@@ -189,11 +189,11 @@ class GenerateQuizModal extends Modal {
 
 				deckItems.forEach(item => {
 					const matches = item.name.toLowerCase().includes(searchTerm);
-					item.element.style.display = matches ? '' : 'none';
+					item.element.toggleClass('hidden', !matches);
 				});
 
 				// Update no results message
-				const visibleItems = deckItems.filter(item => item.element.style.display !== 'none');
+				const visibleItems = deckItems.filter(item => !item.element.hasClass('hidden'));
 				let noResultsMsg = deckList.querySelector('.quiz-deck-no-results') as HTMLElement;
 
 				if (visibleItems.length === 0) {
@@ -203,9 +203,9 @@ class GenerateQuizModal extends Modal {
 							cls: 'quiz-deck-no-results'
 						});
 					}
-					noResultsMsg.style.display = '';
+					noResultsMsg.removeClass('hidden');
 				} else if (noResultsMsg) {
-					noResultsMsg.style.display = 'none';
+					noResultsMsg.addClass('hidden');
 				}
 			});
 
@@ -213,7 +213,7 @@ class GenerateQuizModal extends Modal {
 			selectAllBtn.addEventListener('click', (e) => {
 				e.preventDefault();
 				deckItems.forEach(item => {
-					if (item.element.style.display !== 'none') {
+					if (!item.element.hasClass('hidden')) {
 						selectedDecks.add(item.name);
 						item.checkbox.checked = true;
 					}
@@ -225,7 +225,7 @@ class GenerateQuizModal extends Modal {
 			deselectAllBtn.addEventListener('click', (e) => {
 				e.preventDefault();
 				deckItems.forEach(item => {
-					if (item.element.style.display !== 'none') {
+					if (!item.element.hasClass('hidden')) {
 						selectedDecks.delete(item.name);
 						item.checkbox.checked = false;
 					}

--- a/src/ui/flashcard-browser-view.ts
+++ b/src/ui/flashcard-browser-view.ts
@@ -44,8 +44,9 @@ export class FlashcardBrowserView extends ItemView {
     return 'layers';
   }
 
-   
-  async onOpen(): Promise<void> {
+
+
+  onOpen(): void {
     // Load component
     this.component.load();
 
@@ -91,8 +92,8 @@ export class FlashcardBrowserView extends ItemView {
     this.containerEl.setAttribute('tabindex', '-1');
   }
 
-   
-  async onClose(): Promise<void> {
+
+  onClose(): void {
     // Clean up animation timeout
     if (this.animationTimeoutId !== null) {
       window.clearTimeout(this.animationTimeoutId);

--- a/src/ui/quiz-history-view.ts
+++ b/src/ui/quiz-history-view.ts
@@ -43,13 +43,14 @@ export class QuizHistoryView extends ItemView {
 		return 'history';
 	}
 
-   
-	async onOpen(): Promise<void> {
+
+
+	onOpen(): void {
 		this.queueRender();
 	}
 
-   
-	async onClose(): Promise<void> {
+
+	onClose(): void {
 		this.containerEl.empty();
 	}
 

--- a/src/ui/quiz-view.ts
+++ b/src/ui/quiz-view.ts
@@ -47,16 +47,17 @@ export class QuizView extends ItemView {
 		return 'help-circle';
 	}
 
-   
-	async onOpen(): Promise<void> {
+
+
+	onOpen(): void {
 		this.component = new Component();
 		this.component.load();
 		void this.render();
 		document.addEventListener('keydown', this.keydownHandler);
 	}
 
-   
-	async onClose(): Promise<void> {
+
+	onClose(): void {
 		if (this.debounceTimer !== null) {
 			window.clearTimeout(this.debounceTimer);
 			this.debounceTimer = null;

--- a/src/ui/statistics-view.ts
+++ b/src/ui/statistics-view.ts
@@ -36,13 +36,13 @@ export class StatisticsView extends ItemView {
 		return 'bar-chart';
 	}
 
-   
-	async onOpen(): Promise<void> {
+
+	onOpen(): void {
 		this.queueRender();
 	}
 
-   
-	async onClose(): Promise<void> {
+
+	onClose(): void {
 		this.containerEl.empty();
 	}
 


### PR DESCRIPTION
- Replace direct element.style.display manipulation with CSS classes in generate-quiz-command.ts
- Remove async keyword from onOpen/onClose methods that don't use await
- Use toggleClass, addClass, removeClass, hasClass for element visibility instead of style properties
- Affects: statistics-view, quiz-view, quiz-history-view, flashcard-browser-view

This ensures better theming compatibility and cleaner async/await usage.