### PR TITLE
Fix capitalization in dropdown menu options

### DIFF
--- a/src/ui/flashcard-browser-view.ts
+++ b/src/ui/flashcard-browser-view.ts
@@ -540,14 +540,14 @@ export class FlashcardBrowserView extends ItemView {
     const sortSelect = sortContainer.createEl('select', { cls: 'card-sort-select' });
 
     const sortOptions: Array<{ value: SortOption; label: string }> = [
-      { value: 'created-desc', label: 'Most recently made' },
-      { value: 'created-asc', label: 'Oldest first' },
-      { value: 'updated-desc', label: 'Recently updated' },
-      { value: 'updated-asc', label: 'Least recently updated' },
-      { value: 'due-asc', label: 'Due soonest' },
-      { value: 'due-desc', label: 'Due latest' },
-      { value: 'deck-asc', label: 'Deck (A-Z)' },
-      { value: 'deck-desc', label: 'Deck (Z-A)' },
+      { value: 'created-desc', label: 'most recently made' },
+      { value: 'created-asc', label: 'oldest first' },
+      { value: 'updated-desc', label: 'recently updated' },
+      { value: 'updated-asc', label: 'least recently updated' },
+      { value: 'due-asc', label: 'due soonest' },
+      { value: 'due-desc', label: 'due latest' },
+      { value: 'deck-asc', label: 'deck (A-Z)' },
+      { value: 'deck-desc', label: 'deck (Z-A)' },
     ];
 
     const currentSort = this.viewModel.getSortBy();

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -609,14 +609,14 @@ export class FlashlySettingTab extends PluginSettingTab {
 			.setName('Default sort mode')
 			.setDesc('Default sorting for cards when browsing a deck')
 			.addDropdown(dropdown => dropdown
-				.addOption('created-desc', 'Most recently made')
-				.addOption('created-asc', 'Oldest first')
-				.addOption('updated-desc', 'Recently updated')
-				.addOption('updated-asc', 'Least recently updated')
-				.addOption('due-asc', 'Due soonest')
-				.addOption('due-desc', 'Due latest')
-				.addOption('deck-asc', 'Deck (A-Z)')
-				.addOption('deck-desc', 'Deck (Z-A)')
+				.addOption('created-desc', 'most recently made')
+				.addOption('created-asc', 'oldest first')
+				.addOption('updated-desc', 'recently updated')
+				.addOption('updated-asc', 'least recently updated')
+				.addOption('due-asc', 'due soonest')
+				.addOption('due-desc', 'due latest')
+				.addOption('deck-asc', 'deck (A-Z)')
+				.addOption('deck-desc', 'deck (Z-A)')
 				.setValue(this.plugin.settings.browser.defaultSort)
 				.onChange(async (value) => {
 					this.plugin.settings.browser.defaultSort = value as any;


### PR DESCRIPTION
Update all sort option labels in the flashcard browser and settings to use sentence case (lowercase first letter) for consistency with UI text guidelines.